### PR TITLE
Set splunk index data to be within a volume

### DIFF
--- a/splunk/Dockerfile
+++ b/splunk/Dockerfile
@@ -16,5 +16,6 @@ COPY main_app/ /opt/splunk/etc/apps/main/
 
 COPY init/ /init/
 
+VOLUME /opt/splunk/var/lib/splunk
 EXPOSE 8000 9997
 


### PR DESCRIPTION
Splunk is finicky about the filesystem where its indexes are stored.  I had an error when running this image under boot2docker.  This fixes it.
